### PR TITLE
chapter03 - abstraction

### DIFF
--- a/abstraction/sync_1.py
+++ b/abstraction/sync_1.py
@@ -1,0 +1,40 @@
+import hashlib
+import os
+import shutil
+from pathlib import Path
+
+BLOCKSIZE = 65536
+
+
+def hash_file(path):
+    hasher = hashlib.sha1()
+    with path.open("rb") as file:
+        buf = file.read(BLOCKSIZE)
+        while buf:
+            hasher.update(buf)
+            buf = file.read(BLOCKSIZE)
+    return hasher.hexdigest()
+
+
+def sync(source, dest):
+    source_hashes = {}
+    for folder, _, files in os.walk(source):
+        for file in files:
+            path = Path(folder) / file
+            source_hashes[hash_file(path)] = file
+
+    seen = set()
+
+    for folder, _, files in os.walk(dest):
+        for file in files:
+            dest_path = Path(folder) / file
+            dest_hash = hash_file(dest_path)
+            seen.add(dest_hash)
+            if hash in source_hashes:
+                dest_path.remove()
+            elif dest_hash in source_hashes and file != source_hashes[dest_hash]:
+                shutil.move(dest_path, Path(folder) / source_hashes[dest_hash])
+
+    for src_hash, file in source_hashes.items():
+        if src_hash not in seen:
+            shutil.copy(Path(source) / file, Path(dest) / file)

--- a/abstraction/sync_2.py
+++ b/abstraction/sync_2.py
@@ -1,0 +1,59 @@
+import hashlib
+import os
+import shutil
+from pathlib import Path
+
+BLOCKSIZE = 65536
+
+
+def sync(source, dest):
+    # imperative shell step 1, gather inputs
+    source_hashes = read_paths_and_hashes(source)
+    dest_hashes = read_paths_and_hashes(dest)
+
+    # step 2: call functional core
+    actions = determine_actions(source_hashes, dest_hashes, source, dest)
+
+    # imperative shell step 3, apply outputs
+    for action, *paths in actions:
+        if action == "COPY":
+            shutil.copyfile(*paths)
+        if action == "MOVE":
+            shutil.move(*paths)
+        if action == "DELETE":
+            os.remove(paths[0])
+
+
+def hash_file(path):
+    hasher = hashlib.sha1()
+    with path.open("rb") as file:
+        buf = file.read(BLOCKSIZE)
+        while buf:
+            hasher.update(buf)
+            buf = file.read(BLOCKSIZE)
+    return hasher.hexdigest()
+
+
+def read_paths_and_hashes(root):
+    hashes = {}
+    for folder, _, files in os.walk(root):
+        for fn in files:
+            hashes[hash_file(Path(folder) / fn)] = fn
+    return hashes
+
+
+def determine_actions(source_hashes, dest_hashes, source_folder, dest_folder):
+    for sha, filename in source_hashes.items():
+        if sha not in dest_hashes:
+            sourcepath = Path(source_folder) / filename
+            destpath = Path(dest_folder) / filename
+            yield "COPY", sourcepath, destpath
+
+        elif dest_hashes[sha] != filename:
+            olddestpath = Path(dest_folder) / dest_hashes[sha]
+            newdestpath = Path(dest_folder) / filename
+            yield "MOVE", olddestpath, newdestpath
+
+    for sha, filename in dest_hashes.items():
+        if sha not in source_hashes:
+            yield "DELETE", dest_folder / filename

--- a/abstraction/test_sync_1.py
+++ b/abstraction/test_sync_1.py
@@ -1,0 +1,48 @@
+import shutil
+import tempfile
+from pathlib import Path
+
+from sync_1 import sync
+
+
+class TestE2E:
+    @staticmethod
+    def test_when_a_file_exists_in_the_source_but_not_the_destination():
+        try:
+            source = tempfile.mkdtemp()
+            dest = tempfile.mkdtemp()
+
+            content = "I am a very useful file"
+            (Path(source) / "my-file").write_text(content)
+
+            sync(source, dest)
+
+            expected_path = Path(dest) / "my-file"
+            assert expected_path.exists()
+            assert expected_path.read_text() == content
+
+        finally:
+            shutil.rmtree(source)
+            shutil.rmtree(dest)
+
+    @staticmethod
+    def test_when_a_file_has_been_renamed_in_the_source():
+        try:
+            source = tempfile.mkdtemp()
+            dest = tempfile.mkdtemp()
+
+            content = "I am a file that was renamed"
+            source_path = Path(source) / "source-filename"
+            old_dest_path = Path(dest) / "dest-filename"
+            expected_dest_path = Path(dest) / "source-filename"
+            source_path.write_text(content)
+            old_dest_path.write_text(content)
+
+            sync(source, dest)
+
+            assert old_dest_path.exists() is False
+            assert expected_dest_path.read_text() == content
+
+        finally:
+            shutil.rmtree(source)
+            shutil.rmtree(dest)

--- a/abstraction/test_sync_2.py
+++ b/abstraction/test_sync_2.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from sync_2 import determine_actions
+
+
+def test_when_a_file_exists_in_the_source_but_not_the_destination():
+    source_hashes = {"hash1": "fn1"}
+    dest_hashes = {}
+    actions = determine_actions(source_hashes, dest_hashes, Path("/src"), Path("/dst"))
+    assert list(actions) == [("COPY", Path("/src/fn1"), Path("/dst/fn1"))]
+
+
+def test_when_a_file_has_been_renamed_in_the_source():
+    source_hashes = {"hash1": "fn1"}
+    dest_hashes = {"hash1": "fn2"}
+    actions = determine_actions(source_hashes, dest_hashes, Path("/src"), Path("/dst"))
+    assert list(actions) == [("MOVE", Path("/dst/fn2"), Path("/dst/fn1"))]


### PR DESCRIPTION
한 요소의 변경이 다른 요소를 깨지게 한다면 두 요소는 서로 **결합**되어있다고 하고, 결합된 요소들 사이에 **응집**이 있다고 한다.

전역적인 결합은 코드를 변경하는데 드는 비용을 증가시켜 성가신 존재가 되기도 한다.

이럴 때 추상화를 통해 세부 사항을 감추면 시스템 내 결합 정도를 줄일 수 있다.

![image](https://user-images.githubusercontent.com/72758925/218299790-4c1f11dd-7f4a-4eed-ac03-672effd48ed5.png)


위 사진을 보면 시스템 A와 B 사이에 추상화를 둬서 시스템A가 단순한 추상화에 의존하도록 두어 시스템 B의 변경으로 부터 사용자를 지켜준다.

### 테스트를 위한 추상화

예를 들어 두 파일 디렉토리를 동기화하는 코드를 작성하고 싶다 할 때, 요구사항은 다음과 같다.

- 원본에 파일이 있지만 사본에 없으면 파일을 원본에서 사본으로 복사한다.
- 원본에 파일이 있지만 사본에 있는 내용이 같은 파일과 이름이 다르면 사본의 파일 이름을 원본 파일 이름과 같게 변경한다.
- 사본에 파일이 있지만 원본에는 없다면 사본의 파일을 삭제한다.

I/O 코드와 도메인 로직이 결합되어 있어 두 가지 경우를 테스트하는데 너무 많은 준비 과정이 필요하다. 그리고 코드의 확장성이 떨어진다. (sync_1.py와 test_sync_1.py 참고)

### 추상화 선택과 선택한 추상화의 구현

코드를 역할에 따라 세 부분의 책임으로 나누고, 각 책임을 추상화 한다.

1. os.walk를 사용해 파일 시스템 정보를 얻고, 얻은 여러 파일 경로로부터 파일 내용의 해시를 결정할 수 있다. 이 동작은 원본과 사본 디렉터리에서 모두 비슷하다.
2. 파일이 새 파일인지, 이름이 변경된 파일인지, 중복된 파일인지 결정한다.
3. 원본과 사본을 일치시키기 위해 파일을 복사하거나 옮기거나(이름 바꾸기) 삭제한다.

어떤 주어진 실제 파일 시스템에 대해 함수를 실행하면 어떤 일이 일어날까? → 어떤 주어진 파일 시스템의 **추상화**에 대해 함수를 실행하면 어떤 추상화된 동작이 일어날까?

그리고 비즈니스 로직의 핵심이 들어 있는 저수준 함수를 테스트하여 주 진입 함수인 sync()를 테스트하지 않고도 통합/인수 테스트를 어느 정도 유지하기로 결정할 수 있다. (sync_2.py와 test_sync_2.py 참고)

### 의존성 주입과 가짜를 사용해 에지투에지 테스트

단위 테스트가 아닌 전체 시스템을 한번에 테스트하되, 가짜 I/O를 사용해 에지투에지 테스트를 작성할 수도 있다.

### Mock을 사용하지 않는 이유

- 사용 중인 의존성을 다른 코드로 패치하면 코드를 단위 테스트할 수는 있지만 설계를 개선하는 데는 아무 역할도 하지 못한다. mock.patch를 사용하면 코드가 —dry-run 플래그에 대해 동작하지 않고 FTP서버에 접속해 작동하지 못한다. 이런 경우를 처리하기 위해서는 추상화를 추가해야 한다.
- Mock을 사용한 테스트는 코드베이스의 구현 세부 사항에 더 밀접히 결합된다. 코드와 테스트 사이에 이런 식의 결합이 일어나면 테스트가 더 깨지기 쉬워지는 경향이 있다.
- 테스트 케이스들이 너무 복잡해져서 테스트 코드를 보고 테스트 대상 코드의 동작을 알아내기가 어려워진다.