### PR TITLE
Chapter05 - improve test

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -28,7 +28,9 @@ async def allocate_endpoint(
         raise HTTPException(status_code=400, detail=f"Invalid sku {line.sku}")
 
     try:
-        batchref = await services.allocate(line, repo, session)
+        batchref = await services.allocate(
+            orderline.order_id, orderline.sku, orderline.quantity, repo, session
+        )
     except models.OutOfStock as e:
         raise HTTPException(status_code=400, detail=f"{e}")
     return {"batchref": batchref}

--- a/app/api.py
+++ b/app/api.py
@@ -1,10 +1,12 @@
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adapters.repository import SqlAlchemyRepository
 from app.database import session
 from app.domain import models
-from app.schema import OrderLine
+from app.schema import Batch, OrderLine
 from app.service import services
 
 router = APIRouter()
@@ -34,3 +36,11 @@ async def allocate_endpoint(
     except models.OutOfStock as e:
         raise HTTPException(status_code=400, detail=f"{e}")
     return {"batchref": batchref}
+
+
+@router.post("/add_batch", status_code=status.HTTP_201_CREATED)
+async def add_batch(batch: Batch, session: AsyncSession = Depends(session)) -> dict[str, str]:
+    repo = SqlAlchemyRepository(session)
+    eta = datetime.fromisoformat(batch.eta) if batch.eta else None
+    await services.add_batch(batch.reference, batch.sku, batch.quantity, eta, repo, session)
+    return {"message": "success"}

--- a/app/schema.py
+++ b/app/schema.py
@@ -5,3 +5,10 @@ class OrderLine(BaseModel):
     order_id: str
     sku: str
     quantity: int
+
+
+class Batch(BaseModel):
+    reference: str
+    sku: str
+    quantity: int
+    eta: str

--- a/app/service/services.py
+++ b/app/service/services.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adapters.repository import AbstractRepository
@@ -25,3 +27,15 @@ async def allocate(
     batchref = models.allocate(line, batches)
     session.commit()
     return batchref
+
+
+async def add_batch(
+    ref: str,
+    sku: str,
+    quantity: int,
+    eta: datetime | None,
+    repo: AbstractRepository,
+    session: AsyncSession,
+) -> None:
+    await repo.add(models.Batch(ref, sku, quantity, eta))
+    session.commit()

--- a/app/service/services.py
+++ b/app/service/services.py
@@ -15,7 +15,10 @@ def is_valid_sku(sku: str, batches: list[models.Batch]) -> bool:
     return sku in {b.sku for b in batches}
 
 
-async def allocate(line: OrderLine, repo: AbstractRepository, session: AsyncSession) -> str:
+async def allocate(
+    order_id: str, sku: str, quantity: int, repo: AbstractRepository, session: AsyncSession
+) -> str:
+    line = OrderLine(order_id, sku, quantity)
     batches = await repo.list()
     if not is_valid_sku(line.sku, batches):
         raise InvalidSku(f"Invalid sku {line.sku}")

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -13,7 +13,7 @@ class FakeRepository(AbstractRepository):
     def for_batch(ref: str, sku: str, quantity: int, eta=None):  # type: ignore
         return FakeRepository([Batch(ref, sku, quantity, eta)])
 
-    def add(self, batch: Batch) -> None:
+    async def add(self, batch: Batch) -> None:
         self._batches.add(batch)
 
     async def get(self, reference: str) -> Batch:
@@ -31,24 +31,29 @@ class FakeSession:
 
 
 async def test_returns_allocation() -> None:
-    repo = FakeRepository.for_batch("b1", "COMPLICATED-LAMP", 100, eta=None)
-
+    repo, session = FakeRepository([]), FakeSession()
+    await services.add_batch("b1", "COMPLICATED-LAMP", 100, None, repo, session)
     result = await services.allocate("o1", "COMPLICATED-LAMP", 10, repo, FakeSession())
     assert result == "b1"
 
 
 async def test_error_for_invalid_sku() -> None:
-    batch = Batch("b1", "AREALSKU", 100, eta=None)
-    repo = FakeRepository([batch])
+    repo, session = FakeRepository([]), FakeSession()
+    await services.add_batch("b1", "AREALSKU", 100, None, repo, session)
 
     with pytest.raises(services.InvalidSku, match="Invalid sku NONEXISTENTSKU"):
         await services.allocate("o1", "NONEXISTENTSKU", 10, repo, FakeSession())
 
 
 async def test_commits() -> None:
-    batch = Batch("b1", "OMINOUS-MIRROR", 100, eta=None)
-    repo = FakeRepository([batch])
-    session = FakeSession()
-
+    repo, session = FakeRepository([]), FakeSession()
+    await services.add_batch("b1", "OMINOUS-MIRROR", 100, None, repo, session)
     await services.allocate("o1", "OMINOUS-MIRROR", 10, repo, session)
+    assert session.committed is True
+
+
+async def test_add_batch() -> None:
+    repo, session = FakeRepository([]), FakeSession()
+    await services.add_batch("b1", "SMALL-TABLE", 100, None, repo, session)
+    assert repo.get("b1") is not None
     assert session.committed is True

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,13 +1,17 @@
 import pytest
 
 from app.adapters.repository import AbstractRepository
-from app.domain.models import Batch, OrderLine
+from app.domain.models import Batch
 from app.service import services
 
 
 class FakeRepository(AbstractRepository):
     def __init__(self, batches: list[Batch]) -> None:
         self._batches = set(batches)
+
+    @staticmethod
+    def for_batch(ref: str, sku: str, quantity: int, eta=None):  # type: ignore
+        return FakeRepository([Batch(ref, sku, quantity, eta)])
 
     def add(self, batch: Batch) -> None:
         self._batches.add(batch)
@@ -27,28 +31,24 @@ class FakeSession:
 
 
 async def test_returns_allocation() -> None:
-    line = OrderLine("o1", "COMPLICATED-LAMP", 10)
-    batch = Batch("b1", "COMPLICATED-LAMP", 100, eta=None)
-    repo = FakeRepository([batch])
+    repo = FakeRepository.for_batch("b1", "COMPLICATED-LAMP", 100, eta=None)
 
-    result = await services.allocate(line, repo, FakeSession())
+    result = await services.allocate("o1", "COMPLICATED-LAMP", 10, repo, FakeSession())
     assert result == "b1"
 
 
 async def test_error_for_invalid_sku() -> None:
-    line = OrderLine("o1", "NONEXISTENTSKU", 10)
     batch = Batch("b1", "AREALSKU", 100, eta=None)
     repo = FakeRepository([batch])
 
     with pytest.raises(services.InvalidSku, match="Invalid sku NONEXISTENTSKU"):
-        await services.allocate(line, repo, FakeSession())
+        await services.allocate("o1", "NONEXISTENTSKU", 10, repo, FakeSession())
 
 
 async def test_commits() -> None:
-    line = OrderLine("o1", "OMINOUS-MIRROR", 10)
     batch = Batch("b1", "OMINOUS-MIRROR", 100, eta=None)
     repo = FakeRepository([batch])
     session = FakeSession()
 
-    await services.allocate(line, repo, session)
+    await services.allocate("o1", "OMINOUS-MIRROR", 10, repo, session)
     assert session.committed is True


### PR DESCRIPTION
**<결합과 설계 피드백 사이의 트레이드 오프>**

- API에 대한 테스트는 높은 추상화를 제공하므로 객체의 세부 설계에 대한 피드백을 제공하지 않고 데이터베이스 스키마 변경 등의 대규모 변경 시에도 본래의 작동을 보장해준다.
- 도메인에 대한 테스트는 시스템이 어떻게 동작하는지, 핵심 개념이 서로 어떻게 연관되어 있는지 이해하는데 도움을 준다.

서비스 계층 테스트를 도메인으로부터 완전히 분리하여 새로운 기능을 추가하거나 수정할 때 도메인 모델을 크게 변경할 필요가 없게 만든다.

![image](https://user-images.githubusercontent.com/72758925/218308246-80808b78-5a0c-4ab5-b660-81d01431cd2f.png)

- 서비스 계층을 도메인 객체가 아니라 원시 타입을 바탕으로 기술하라.
- 이상적인 경우라면 테스트해야 할 모든 서비스를 저장소나 데이터베이스를 통해 상태를 해킹할 필요 없이 오직 서비스 계층 기반으로 테스트할 수 있다. 이렇게 한다면 나중에 엔드투엔드 테스트에서도 이익을 얻을 수 있다.